### PR TITLE
Fix for encoding Error under Matrix

### DIFF
--- a/resources/lib/xmlfunctions.py
+++ b/resources/lib/xmlfunctions.py
@@ -674,7 +674,7 @@ class XMLFunctions():
             hasher = hashlib.md5()
             hasher.update(xbmcvfs.File(path).read().encode("utf-8"))
 
-            with open(path, "r+") as f:
+            with open(path, "r+", encoding="utf-8") as f:
                 DATA._save_hash( path, f.read() )
                 f.close()
 


### PR DESCRIPTION
Fixes an error that happens for me at the menu building process with Arctic Zephyr 2:
```
ERROR <general>: File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/script.skinshortcuts/resources/lib/xmlfunctions.py", line 88, in buildMenu
                    self.writexml( profilelist, mainmenuID, groups, numLevels, buildMode, progress, options, minitems )

ERROR <general>: File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/script.skinshortcuts/resources/lib/xmlfunctions.py", line 678, in writexml
                    DATA._save_hash( path, f.read() )

ERROR <general>: File "/data/user/0/org.xbmc.kodi/cache/apk/assets/python3.7/lib/python3.7/encodings/ascii.py", line 26, in decode
                    return codecs.ascii_decode(input, self.errors)[0]

ERROR <general>: UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 183: ordinal not in range(128)
```