### PR TITLE
Add Games as type for widgets

### DIFF
--- a/resources/lib/library.py
+++ b/resources/lib/library.py
@@ -1528,6 +1528,17 @@ class LibraryFunctions():
                     listitem.setProperty( "widgetName", dialogLabel )
                     listitem.setProperty( "widgetPath", location )
 
+                elif itemType == "32123":
+                    action = 'ActivateWindow(Games,"' + location + '",return)'
+                    listitem.setProperty( "windowID", "Games" )
+
+                    # Add widget details
+                    listitem.setProperty( "widget", "Addon" )
+                    listitem.setProperty( "widgetType", "game" )
+                    listitem.setProperty( "widgetTarget", "games" )
+                    listitem.setProperty( "widgetName", dialogLabel )
+                    listitem.setProperty( "widgetPath", location )
+                    
                 else:
                     action = "RunAddon(" + location + ")"
 


### PR DESCRIPTION
In my overrides.xml, I was unable to set a widget with type "games", as there was no string type that pointed to games. There were only strings 32009 = Program, 32010 = Video Add-on. 32011 = Music Add-on and 32012 = Picture Addon. So, I added a new string (32123 = Games). So now the game widgets open in the Games.xml window.