### PR TITLE
Fixed escaping exception with thumbnail paths and optional property patterns

### DIFF
--- a/resources/lib/xmlfunctions.py
+++ b/resources/lib/xmlfunctions.py
@@ -971,7 +971,7 @@ class XMLFunctions():
                 propertyPattern = propertyPatterns[propertyName][0]
                 for original, replacement in propertyReplacements:
                     regexpPattern = re.compile(re.escape(original), re.IGNORECASE)
-                    propertyPattern = regexpPattern.sub(replacement, propertyPattern)
+                    propertyPattern = regexpPattern.sub(replacement.replace("\\", r"\\"), propertyPattern)
 
                 additionalproperty = xmltree.SubElement(newelement, "property")
                 additionalproperty.set("name", propertyName)


### PR DESCRIPTION
@mikesilvo164 

If you have set `<propertypattern>` and a custom thumbnail it will cause an exception of `re.sub()` because a path like `g:\test.jpg` has a backslash included.

This backslash needs to be escaped. This small line fixes the issue and will handle the `\` as string.

