### PR TITLE
[favourites] only add return if the builtin is ActivateWindow

### DIFF
--- a/resources/lib/skinshorcuts/library.py
+++ b/resources/lib/skinshorcuts/library.py
@@ -1393,7 +1393,7 @@ class LibraryFunctions:
         for favourite in listing:
             name = favourite.attributes['name'].nodeValue
             path = favourite.childNodes[0].nodeValue
-            if ('RunScript' not in path) and ('StartAndroidActivity' not in path) and \
+            if path.lower().startswith('activatewindow') and \
                     not path.endswith(',return)'):
                 path = path.rstrip(')')
                 path = '%s,return)' % path


### PR DESCRIPTION
This was reported in the kodi core repo: https://github.com/xbmc/xbmc/issues/20648
While investigating it decided to fix it too - there's no reason to append return) to any builtin unless the builtin is `ActivateWindow` where the parameter actually takes any effect.
@anxdpanic by the commit history I think you might have access to this repo right?