### PR TITLE
Fix incorrect translation in PVR

### DIFF
--- a/resources/lib/skinshorcuts/library.py
+++ b/resources/lib/skinshorcuts/library.py
@@ -1048,7 +1048,7 @@ class LibraryFunctions:
             self.create(["ActivateWindow(TVGuide)", "22020", "32017", {
                 "icon": "DefaultTVShows.png"
             }]),
-            self.create(["ActivateWindow(TVRecordings)", "19163", "32017", {
+            self.create(["ActivateWindow(TVRecordings)", "19017", "32017", {
                 "icon": "DefaultTVShows.png"
             }]),
             self.create(["ActivateWindow(TVTimers)", "19040", "32017", {
@@ -1115,7 +1115,7 @@ class LibraryFunctions:
             self.create(["ActivateWindow(RadioGuide)", "22020", "32087", {
                 "icon": "DefaultAudio.png"
             }]),
-            self.create(["ActivateWindow(RadioRecordings)", "19163", "32087", {
+            self.create(["ActivateWindow(RadioRecordings)", "19017", "32087", {
                 "icon": "DefaultAudio.png"
             }]),
             self.create(["ActivateWindow(RadioTimers)", "19040", "32087", {

--- a/resources/shortcuts/livetv.DATA.xml
+++ b/resources/shortcuts/livetv.DATA.xml
@@ -9,7 +9,7 @@
 		<version>14</version>
 	</shortcut>
 	<shortcut>
-		<label>19163</label>
+		<label>19017</label>
 		<label2>32017</label2>
 		<icon>DefaultTVShows.png</icon>
 		<thumb />
@@ -17,7 +17,7 @@
 		<version>13</version>
 	</shortcut>
 	<shortcut>
-		<label>19163</label>
+		<label>19017</label>
 		<label2>32017</label2>
 		<icon>DefaultTVShows.png</icon>
 		<thumb />


### PR DESCRIPTION
There's incorrect translation used in livetv.DATA.xml and library.py

According to Weblate 19163 is "label for number of PVR recordings in system information's PVR section"

So I replaced it with 19017 which is "generic label for pvr recordings used in different places"